### PR TITLE
Use Craft's native control panel and permission entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes for Reporter
 
+## 1.2.0 - TBD
+
+> {warning} This update modifies the permission behavior of the plugin. If you have given permissions to users or user groups for Reporter you will need to re-enable these under the "General" section of Craft's permission utility for each user/group.
+
+### Updated
+- Use `$hasCpSection` to insert Reporter navigation link in the control panel. This ensures it's ordered properly in the sidebar by Craft.
+- Use Craft's baked-in permissions when using `$hasCpSection` instead of custom one.
+
 ## 1.1.0 - 2022-02-17
 
 ### Updated

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -4,18 +4,16 @@ namespace trendyminds\reporter;
 
 use Craft;
 use craft\base\Plugin;
-use craft\events\RegisterCpNavItemsEvent;
-use craft\web\twig\variables\Cp;
 use craft\events\RegisterUrlRulesEvent;
-use craft\events\RegisterUserPermissionsEvent;
 use craft\models\VolumeFolder;
-use craft\services\UserPermissions;
 use craft\web\UrlManager;
 use Stringy\Stringy;
 use yii\base\Event;
 
 class Reporter extends Plugin
 {
+	public $hasCpSection = true;
+
 	public function init()
 	{
 		parent::init();
@@ -27,35 +25,6 @@ class Reporter extends Plugin
 			function (RegisterUrlRulesEvent $event) {
 				$event->rules['reporter'] = 'reporter/default/index';
 				$event->rules['reporter/exports'] = 'reporter/default/exports';
-			}
-		);
-
-		// Setup the control panel navigation link
-		Event::on(
-			Cp::class,
-			Cp::EVENT_REGISTER_CP_NAV_ITEMS,
-			function(RegisterCpNavItemsEvent $event) {
-				// Add the navigation item if the user has access to Reporter
-				if (Craft::$app->user->checkPermission('accessReporter')) {
-					$event->navItems[] = [
-						'url' => 'reporter',
-						'label' => $this->getSettings()->displayName,
-						'icon' => '@trendyminds/reporter/icon-mask.svg'
-					];
-				}
-			}
-		);
-
-		// Setup user permissions to access the plugin area
-		Event::on(
-			UserPermissions::class,
-			UserPermissions::EVENT_REGISTER_PERMISSIONS,
-			function(RegisterUserPermissionsEvent $event) {
-				$event->permissions['Reporter'] = [
-					'accessReporter' => [
-						'label' => 'Access Reporter',
-					],
-				];
 			}
 		);
 	}

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -17,7 +17,7 @@ class DefaultController extends Controller
 	 */
 	public function actionIndex()
 	{
-		$this->requirePermission('accessReporter');
+		$this->requirePermission('accessPlugin-reporter');
 
 		return $this->renderTemplate("reporter/index", [
 			'displayName' => Reporter::getInstance()->getSettings()->displayName,
@@ -39,7 +39,7 @@ class DefaultController extends Controller
 	 */
 	public function actionExports()
 	{
-		$this->requirePermission('accessReporter');
+		$this->requirePermission('accessPlugin-reporter');
 
 		$folderVolume = Reporter::getInstance()->getExportPath();
 
@@ -53,7 +53,7 @@ class DefaultController extends Controller
 	 */
 	public function actionRun()
 	{
-		$this->requirePermission('accessReporter');
+		$this->requirePermission('accessPlugin-reporter');
 		$this->requirePostRequest();
 
 		$reportHandle = $this->request->getRequiredBodyParam('report');


### PR DESCRIPTION
### Updated
- Use `$hasCpSection` to insert Reporter navigation link in the control panel. This ensures it's ordered properly in the sidebar by Craft.
- Use Craft's baked-in permissions when using `$hasCpSection` instead of custom one.
