### PR TITLE
Add UTF-8 BOM to the generated CSV file to prevent encoding issues

### DIFF
--- a/src/jobs/ExportJob.php
+++ b/src/jobs/ExportJob.php
@@ -41,6 +41,11 @@ class ExportJob extends BaseJob
 		// Create the first header row
 		$headers = array_keys($record);
 		$output = fopen($filePath, "w+");
+		
+		// Add the BOM for UTF-8
+		fwrite($output, "\xEF\xBB\xBF");
+		
+		// Write the header row to the CSV
 		fputcsv($output, $headers);
 
 		// Loop through each element and insert it into the CSV as a new row


### PR DESCRIPTION
This PR adds a UTF-8 Byte Order Mark (BOM) to the beginning of the generated CSV file. This helps to prevent encoding issues when opening the file in software like Microsoft Excel. The changes include:

- Adding a BOM to the CSV file right after creating it and before writing the headers
- Updating the file writing process to accommodate the BOM addition
With these changes, the exported CSV file should display correctly in various applications without encoding issues.